### PR TITLE
Solved the issue in recreation of EvernoteSession by providing getters for  EvernoteSession class members

### DIFF
--- a/src/com/evernote/client/oauth/android/EvernoteSession.java
+++ b/src/com/evernote/client/oauth/android/EvernoteSession.java
@@ -171,4 +171,61 @@ public class EvernoteSession {
       return result;
     }
   }
+  
+  	/**
+	 * Get the ApplicationInfo object
+	 * 
+	 * @return applicationInfo object
+	 */
+	public ApplicationInfo getApplicationInfo() {
+		return applicationInfo;
+	}
+
+	/**
+	 * Set the ApplicationInfo object
+	 * 
+	 * @param applicationInfo
+	 */
+	public void setApplicationInfo(ApplicationInfo applicationInfo) {
+		this.applicationInfo = applicationInfo;
+	}
+
+	/**
+	 * Get the AuthenticationResult. Useful to recreate the session
+	 * 
+	 * @return authenticationResult object
+	 */
+	public AuthenticationResult getAuthenticationResult() {
+		return authenticationResult;
+	}
+
+	/**
+	 * Set the AuthenticationResult.
+	 * 
+	 * @param authenticationResult
+	 */
+	public void setAuthenticationResult(
+			AuthenticationResult authenticationResult) {
+		this.authenticationResult = authenticationResult;
+	}
+
+	/**
+	 * Get a temporary directory that was set by client application to store potentially 
+	 * large files sent to and retrieved from the Evernote API.
+	 * 
+	 * @return File object pointing to temporary directory
+	 */
+	public File getTempDir() {
+		return tempDir;
+	}
+
+	/**
+	 * Set the temporary directory to store potentially 
+	 * large files sent to and retrieved from the Evernote API.
+	 * 
+	 * @param File tempDir
+	 */
+	public void setTempDir(File tempDir) {
+		this.tempDir = tempDir;
+	}
 }


### PR DESCRIPTION
Added Getters and Setters for EvernoteSession class members to enable  recreation of session in Android Client applications.
Earlier there was no way to get the NoteStoreUrl and WebApiUrlPrefix (i.e. AuthenticationResult object") so that EvernoteSession can be recreated without having to reauthenticate using OAuth. 

With these getters, developers will be able to recreate the session very easily by storing the AuthenticationResult object contents in a persistence storage.
