### PR TITLE
Value of REQUEST_CODE_OAUTH on EvernoteSession needs to be <= 0xffff.

### DIFF
--- a/library/src/com/evernote/client/oauth/android/EvernoteSession.java
+++ b/library/src/com/evernote/client/oauth/android/EvernoteSession.java
@@ -96,7 +96,7 @@ public class EvernoteSession {
   protected static final String KEY_NOTESTOREURL = "evernote.notestoreUrl";
   protected static final String KEY_WEBAPIURLPREFIX = "evernote.webApiUrlPrefix";
   protected static final String KEY_USERID = "evernote.userId";
-  public static final int REQUEST_CODE_OAUTH = 1010101;
+  public static final int REQUEST_CODE_OAUTH = 10101;
 
   protected static final String PREFERENCE_NAME = "evernote.preferences";
 


### PR DESCRIPTION
The value of the `REQUEST_CODE_OAUTH` constant on the `EvernoteSession` class, needs to be changed to a value that's less than 0xffff to allow for compatibility with the `FragmentActivity` class on Android's support library.

**Background:**
The Support Library v4 implements a `FragmentActivity` class that is used when an activity needs to use the support versions of the Fragment and Loader APIs. The issue is that the `startActivityForResult(...)` method on that class has a limitation where the passed requestCode can't be greater than 0xffff (see [here](http://bit.ly/UF7k0J))

Since the value of `REQUEST_CODE_OAUTH` is currently higher than the specified limit, if an app sends a `FragmentActivity` as the Context parameter to the `authenticate` method of  `EvernoteSession`, it will result in an `IllegalArgumentException` when that method tries to call `startActivityForResult(...)` passing `REQUEST_CODE_OAUTH` as the requestCode parameter.

A sample LogCat of the error can be seen [here](https://www.evernote.com/shard/s192/sh/0f979fda-efb0-4d04-9be4-995cd4bb92b9/0f6c3d05a6282de85a988c7180b2b272).
